### PR TITLE
linter: prevent using blocks without curly braces and warn if debugge…

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -72,9 +72,10 @@
       ],
       "vue/eqeqeq": "error",
       "semi": "error",
-      "no-console": "off",
-      "no-debugger": "off",
-      "eqeqeq": "error"
+      "no-console": "warn",
+      "no-debugger": "warn",
+      "eqeqeq": "error",
+      "curly": "error"
     }
   },
   "browserslist": [

--- a/client/src/components/guard/UserDataProvider.vue
+++ b/client/src/components/guard/UserDataProvider.vue
@@ -15,7 +15,6 @@ export default {
                 await store.dispatch('auth/' + actions.FETCH_LOGGED_USER);
                 next();
             } catch (error) {
-                console.log(error);
                 next(false);
             }
         } else {


### PR DESCRIPTION
…r or console.log was left in the code