### PR TITLE
Change link on logo

### DIFF
--- a/client/src/components/common/GeneralLayout/Logo.vue
+++ b/client/src/components/common/GeneralLayout/Logo.vue
@@ -1,6 +1,6 @@
 <template>
     <VToolbarTitle class="logo">
-        <RouterLink class="logo__link" :to="{ name: 'Home' }">
+        <RouterLink class="logo__link" :to="{ name: 'EventTypes' }">
             <img class="logo__image" :src="require('@/assets/logo.svg')" />
             <span class="logo__text">{{ lang.SCHEDULIA }}</span>
         </RouterLink>


### PR DESCRIPTION
The task in Trello https://trello.com/c/XTTJ3sUu/222-authorized-user-is-redirected-to-the-plug-page-after-clicking-at-logo

Now, if we stand on /event-types and click on the logo the page is not reloaded. Now the tabs don't worked how links, but this task in production and when we finished this task - we don't need to reload /event-types page